### PR TITLE
chore: dependency updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ module.exports = function run (patterns, opts) {
     const next = after(files.length, (err) => {
       if (err) return output.destroy(err)
       const flat = streams.reduce((a, el) => a.concat(el), [])
-      pump(multi(flat), output)
+      pump(new multi(flat), output)
     })
 
     files.forEach((file, index) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,7 +215,7 @@ module.exports = function run (patterns, opts) {
 
   function runFile (type, script, file, name, prefix) {
     const lines = lineWriter()
-        , p = parser()
+        , p = new parser()
 
     process.nextTick(function() {
       const stderr = opts.stderr ? process.stderr : 'ignore'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "multistream": "~2.1.0",
     "pump": "^3.0.0",
     "tap-parser": "~3.0.3",
-    "through2": "~2.0.1",
+    "through2": "^3.0.1",
     "xtend": "~4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "xtend": "~4.0.1"
   },
   "devDependencies": {
-    "concat-stream": "~1.6.2",
+    "concat-stream": "^2.0.0",
     "dependency-check": "~3.2.0",
     "npm-run-all": "~4.1.3",
     "tape": "~4.9.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^4.1.1",
     "existent": "~1.0.1",
     "glob": "~7.1.1",
-    "js-yaml": "~3.6.1",
+    "js-yaml": "^3.13.1",
     "micromatch": "^4.0.2",
     "minimist": "~1.2.0",
     "multistream": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concat-stream": "^2.0.0",
     "dependency-check": "^4.1.0",
     "npm-run-all": "~4.1.3",
-    "tape": "~4.9.1"
+    "tape": "^4.12.1"
   },
   "keywords": [
     "test",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "existent": "~1.0.1",
     "glob": "~7.1.1",
     "js-yaml": "~3.6.1",
-    "micromatch": "~2.3.11",
+    "micromatch": "^4.0.2",
     "minimist": "~1.2.0",
     "multistream": "~2.1.0",
     "pump": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "after": "~0.8.2",
     "common-prefix": "~1.1.0",
     "cross-spawn": "~4.0.2",
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "existent": "~1.0.1",
     "glob": "~7.1.1",
     "js-yaml": "~3.6.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lib"
   ],
   "scripts": {
-    "check:missing": "dependency-check package.json lib/bin.js",
+    "check:missing": "dependency-check package.json lib/bin.js --missing",
     "check:unused": "dependency-check package.json lib/bin.js --unused --no-dev",
     "test": "npm-run-all --silent check:* 1>&2 && tape test/*.js"
   },
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",
-    "dependency-check": "~3.2.0",
+    "dependency-check": "^4.1.0",
     "npm-run-all": "~4.1.3",
     "tape": "~4.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "js-yaml": "^3.13.1",
     "micromatch": "^4.0.2",
     "minimist": "~1.2.0",
-    "multistream": "~2.1.0",
+    "multistream": "^4.0.0",
     "pump": "^3.0.0",
     "tap-parser": "^10.0.1",
     "through2": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "micromatch": "^4.0.2",
     "minimist": "~1.2.0",
     "multistream": "~2.1.0",
-    "pump": "~1.0.1",
+    "pump": "^3.0.0",
     "tap-parser": "~3.0.3",
     "through2": "~2.0.1",
     "xtend": "~4.0.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "~1.2.0",
     "multistream": "~2.1.0",
     "pump": "^3.0.0",
-    "tap-parser": "~3.0.3",
+    "tap-parser": "^10.0.1",
     "through2": "^3.0.1",
     "xtend": "~4.0.1"
   },

--- a/test/basic/ok1+fail1.txt
+++ b/test/basic/ok1+fail1.txt
@@ -10,6 +10,7 @@ not ok 2 should be equal
     at: 'Test.fail1 (${dir}fail1.js:2:5)'
   ...
 
+# failed 1 test
 1..2
 # tests 2
 # pass  1

--- a/test/basic/ok1+ok2+error1.txt
+++ b/test/basic/ok1+ok2+error1.txt
@@ -6,6 +6,8 @@ ok 2 test 2
 # error1a
 ok 3 error1a
 # error1b
+# test count(1) != plan(null)
+# failed 1 test
 not ok 4 error1.js exited with code 1
 1..4
 # tests 4

--- a/test/basic/ok2+skip1.txt
+++ b/test/basic/ok2+skip1.txt
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 test 2
 # skip1
 ok 2 true # skip
+# skip: 1
 1..2
 # tests 2
 # pass  2

--- a/test/double-pass/tap.txt
+++ b/test/double-pass/tap.txt
@@ -12,6 +12,9 @@ ok 8 # todo message
 ok 9 ok # todo
 ok 10 ok # todo message
 not ok 11
+# failed 1 of 11 tests
+# skip: 4
+# todo: 4
 1..11
 # tests 11
 # pass  10

--- a/test/multiple-scripts.js
+++ b/test/multiple-scripts.js
@@ -14,7 +14,16 @@ test('-r test', function (t) {
 
   run(['-r', 'test'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
-    t.is(stdout.trim(), wrap(['# name', 'ok 1 test'], 1), 'tap ok')
+    t.is(stdout.trim(), join([
+      'TAP version 13',
+      '# name',
+      'ok 1 test',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ], 1), 'tap ok')
     t.is(stderr, '', 'empty stderr')
   })
 })
@@ -24,7 +33,16 @@ test('defaults to -r test', function (t) {
 
   run([], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
-    t.is(stdout.trim(), wrap(['# name', 'ok 1 test'], 1), 'tap ok')
+    t.is(stdout.trim(), join([
+      'TAP version 13',
+      '# name',
+      'ok 1 test',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ]), 'tap ok')
     t.is(stderr, '', 'empty stderr')
   })
 })
@@ -35,11 +53,17 @@ test('-r test -r test:a', function (t) {
   run(['-r', 'test', '-r', 'test:a'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# name',
       'ok 1 test',
       '# :a › name',
-      'ok 2 test:a'
+      'ok 2 test:a',
+      '1..2',
+      '# tests 2',
+      '# pass  2',
+      '',
+      '# ok'
     ], 2), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
@@ -52,12 +76,18 @@ test('-r test:a -r test:b', function (t) {
   run(['-r', 'test:a', '-r', 'test:b'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# a › name',
       'ok 1 test:a',
       '# b › name',
-      'ok 2 test:b'
-    ], 2), 'tap ok')
+      'ok 2 test:b',
+      '1..2',
+      '# tests 2',
+      '# pass  2',
+      '',
+      '# ok'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -69,12 +99,18 @@ test('-r test:*', function (t) {
   run(['-r', 'test:*'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# a › name',
       'ok 1 test:a',
       '# b › name',
-      'ok 2 test:b'
-    ], 2), 'tap ok')
+      'ok 2 test:b',
+      '1..2',
+      '# tests 2',
+      '# pass  2',
+      '',
+      '# ok'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -85,7 +121,16 @@ test('-r deep:a:*', function (t) {
 
   run(['-r', 'deep:a:*'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
-    t.is(stdout.trim(), wrap(['# name', 'ok 1 deep:a:b'], 1), 'tap ok')
+    t.is(stdout.trim(), join([
+      'TAP version 13',
+      '# name',
+      'ok 1 deep:a:b',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ]), 'tap ok')
     t.is(stderr, '', 'empty stderr')
   })
 })
@@ -96,12 +141,18 @@ test('-r deep:a:**', function (t) {
   run(['-r', 'deep:a:**'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# name',
       'ok 1 deep:a:b',
       '# :c › name',
       'ok 2 deep:a:b:c',
-    ], 2), 'tap ok')
+      '1..2',
+      '# tests 2',
+      '# pass  2',
+      '',
+      '# ok'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -113,14 +164,20 @@ test('-r deep:a:** with js', function (t) {
   run(['-r', 'deep:a:**', '.', 'test.js'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# name',
       'ok 1 deep:a:b',
       '# :c › name',
       'ok 2 deep:a:b:c',
       '# name',
       'ok 3 js',
-    ], 3), 'tap ok')
+      '1..3',
+      '# tests 3',
+      '# pass  3',
+      '',
+      '# ok'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -132,10 +189,16 @@ test('-r non-existent --ignore-missing', function (t) {
   run(['-r', 'non-existent', '--ignore-missing'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# -',
-      'ok 1 # skip no npm script(s) matching "non-existent"'
-    ], 1), 'tap ok')
+      'ok 1 # skip no npm script(s) matching "non-existent"',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -147,10 +210,15 @@ test('-r non-existent', function (t) {
   run(['-r', 'non-existent'], (err, stdout, stderr) => {
     t.is(err && err.code, 1, 'exited with code 1')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# -',
-      'not ok 1 # TODO no npm script(s) matching "non-existent"'
-    ], 0, 1), 'tap ok')
+      'not ok 1 # TODO no npm script(s) matching "non-existent"',
+      '1..1',
+      '# tests 1',
+      '# pass  0',
+      '# fail  1',
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -162,12 +230,17 @@ test('-r test -r non-existent', function (t) {
   run(['-r', 'test', '-r', 'non-existent'], (err, stdout, stderr) => {
     t.is(err && err.code, 1, 'exited with code 1')
 
-    t.is(stdout.trim(), wrap([
+    t.is(stdout.trim(), join([
+      'TAP version 13',
       '# name',
       'ok 1 test',
       '# -',
-      'not ok 2 # TODO no npm script(s) matching "non-existent"'
-    ], 1, 1), 'tap ok')
+      'not ok 2 # TODO no npm script(s) matching "non-existent"',
+      '1..2',
+      '# tests 2',
+      '# pass  1',
+      '# fail  1'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -178,7 +251,16 @@ test('-r {test,non-existent}', function (t) {
 
   run(['-r', '{test,non-existent}'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
-    t.is(stdout.trim(), wrap(['# name', 'ok 1 test'], 1), 'tap ok')
+    t.is(stdout.trim(), join([
+      'TAP version 13',
+      '# name',
+      'ok 1 test',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ]), 'tap ok')
     t.is(stderr, '', 'empty stderr')
   })
 })
@@ -188,7 +270,16 @@ test('-r test --stderr', function (t) {
 
   run(['-r', 'test', '--stderr'], (err, stdout, stderr) => {
     t.ifError(err, 'no exec error')
-    t.is(stdout.trim(), wrap(['# name', 'ok 1 test'], 1), 'tap ok')
+    t.is(stdout.trim(), join([
+      'TAP version 13',
+      '# name',
+      'ok 1 test',
+      '1..1',
+      '# tests 1',
+      '# pass  1',
+      '',
+      '# ok'
+    ]), 'tap ok')
     t.is(stderr, 'test\n', 'stderr ok')
   })
 })
@@ -201,7 +292,8 @@ test('-r fail', function (t) {
 
     // console.error('---\n' + stdout + '\n---')
 
-    t.is(removeStackTrace(stdout.trim()), wrap([
+    t.is(removeStackTrace(stdout.trim()), join([
+      'TAP version 13',
       '# name',
       'ok 1 fail',
       'not ok 2 fail',
@@ -213,8 +305,13 @@ test('-r fail', function (t) {
       `      Test.<anonymous>`,
       `      (${filename}:12:7)`,
       '  ...',
-      ''
-    ], 1, 1), 'tap ok')
+      '',
+      '# failed 1 of 2 tests',
+      '1..2',
+      '# tests 2',
+      '# pass  1',
+      '# fail  1'
+    ]), 'tap ok')
     t.is(stderr, '', 'empty stderr')
   })
 })
@@ -227,7 +324,8 @@ test('-r test:a -r fail -r test:b', function (t) {
 
     // console.error('---\n' + stdout + '\n---')
 
-    t.is(removeStackTrace(stdout.trim()), wrap([
+    t.is(removeStackTrace(stdout.trim()), join([
+      'TAP version 13',
       '# test:a › name',
       'ok 1 test:a',
       '# fail › name',
@@ -242,9 +340,14 @@ test('-r test:a -r fail -r test:b', function (t) {
       `      (${filename}:12:7)`,
       '  ...',
       '',
+      '# fail › failed 1 of 2 tests',
       '# test:b › name',
       'ok 4 test:b',
-    ], 3, 1), 'tap ok')
+      '1..4',
+      '# tests 4',
+      '# pass  3',
+      '# fail  1'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -258,7 +361,8 @@ test('-r test:a -r fail -r test:b --fail-fast', function (t) {
 
     // console.error('---\n' + stdout + '\n---')
 
-    t.is(removeStackTrace(stdout.trim()), wrap([
+    t.is(removeStackTrace(stdout.trim()), join([
+      'TAP version 13',
       '# test:a › name',
       'ok 1 test:a',
       '# fail › name',
@@ -272,8 +376,13 @@ test('-r test:a -r fail -r test:b --fail-fast', function (t) {
       `      Test.<anonymous>`,
       `      (${filename}:12:7)`,
       '  ...',
-      ''
-    ], 2, 1), 'tap ok')
+      '',
+      '# fail › failed 1 of 2 tests',
+      '1..3',
+      '# tests 3',
+      '# pass  2',
+      '# fail  1'
+    ]), 'tap ok')
 
     t.is(stderr, '', 'empty stderr')
   })
@@ -283,23 +392,7 @@ function run(args, cb) {
   execFile('node', [bin].concat(args), { cwd }, cb)
 }
 
-function wrap (lines, pass, fail) {
-  pass = pass || 0
-  fail = fail || 0
 
-  const wrapped = ['TAP version 13'].concat(lines)
-  const count = pass + fail
-
-  wrapped.push(`1..${count}`)
-  wrapped.push(`# tests ${count}`)
-  wrapped.push(`# pass  ${pass}`)
-
-  if (fail) {
-    wrapped.push(`# fail  ${fail}`)
-  } else {
-    wrapped.push(``)
-    wrapped.push(`# ok`)
-  }
-
-  return wrapped.join('\n')
+function join(lines) {
+  return lines.join('\n');
 }


### PR DESCRIPTION
This updates everything except cross-spawn, which has changes that cause test failures and reordering and is a non-trivial update.

I've updated tap-parser all the way to 10, and made some significant changes to the reference test output to accommodate its additional information.